### PR TITLE
fix(contact): prevent email label overflow on contact cards

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -50,14 +50,14 @@ const contactLinks = [
         data-animate-delay={String(i + 1)}
         target={icon !== 'mail' ? '_blank' : undefined}
         rel={icon !== 'mail' ? 'noopener noreferrer' : undefined}
-        class="section-card group flex flex-col items-center gap-3 rounded-2xl border border-[hsl(var(--parchment))] bg-[hsl(var(--card))] p-6 text-center transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-card-hover)] focus-ring"
+        class="section-card group flex min-w-0 flex-col items-center gap-3 rounded-2xl border border-[hsl(var(--parchment))] bg-[hsl(var(--card))] p-6 text-center transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-card-hover)] focus-ring"
       >
         <div class="flex size-12 items-center justify-center rounded-xl bg-[hsl(var(--primary))]/10 text-[hsl(var(--primary))] transition-transform duration-200 group-hover:scale-110">
           {icon === 'mail' && <MailIcon class="size-5" />}
           {icon === 'linkedin' && <LinkedInIcon class="size-5" />}
           {icon === 'github' && <GitHubIcon class="size-5" />}
         </div>
-        <span class="text-sm font-semibold text-foreground">{label}</span>
+        <span class="w-full break-words text-sm font-semibold text-foreground">{label}</span>
         <span class="text-xs text-[hsl(var(--caption-color))]">{description}</span>
       </a>
     ))}


### PR DESCRIPTION
## Summary
- Email label on the Contact card overflowed the card boundary and overlapped the LinkedIn/GitHub cards, because the `<a>` grid item and the label `<span>` had no width constraint against the unbreakable email string.
- Adds `min-w-0` to the card and `w-full break-words` to the label so the text wraps inside the card at any breakpoint.

## Test plan
- [x] Verified with Playwright screenshot at 1349x900 (desktop): email wraps to two lines, no overlap with LinkedIn/GitHub cards.
- [x] Verified with Playwright screenshot at 390x844 (mobile): single-column layout, email fits without overflow.